### PR TITLE
Feat: Added support for Clay_OnHover, Clay_Hovered, and a FontManager

### DIFF
--- a/BeefProj.toml
+++ b/BeefProj.toml
@@ -11,4 +11,4 @@ LibPaths = ["$(ProjectDir)/libs/windows/clay.lib"]
 PostBuildCmds = ["CopyToDependents(\"$(ProjectDir)/libs/windows/*.lib\")"]
 
 [Configs.Release.Win64]
-LibPaths = ["$(ProjectDir)/lib/windows/clay.lib"]
+LibPaths = ["$(ProjectDir)/libs/windows/clay.lib"]

--- a/example/src/Example.bf
+++ b/example/src/Example.bf
@@ -17,6 +17,7 @@ static class Example
 
 	private static void EmscriptenMainLoop()
 	{
+		Update();
 		Render();
 	}
 #endif
@@ -24,9 +25,9 @@ static class Example
 	public static void Init()
 	{
 		SetTargetFPS(60);
-		SetConfigFlags(RaylibBeef.ConfigFlags.FlagMsaa4XHint);
+		SetConfigFlags(RaylibBeef.ConfigFlags.FLAG_MSAA_4X_HINT);
 		InitWindow(1366, 768, scope $"Clay Beef");
-		SetWindowState(.FlagWindowResizable);
+		SetWindowState(.FLAG_WINDOW_RESIZABLE);
 
 		ClayHomepage.Init();
 
@@ -35,21 +36,28 @@ static class Example
 #else
 		while (!WindowShouldClose())
 		{
+            Update();
 			Render();
 		}
 #endif
 	}
+
+    static void Update()
+    {
+        let mousePos = GetMousePosition();
+        let mouseWheel = GetMouseWheelMoveV();
+
+        ClayHomepage.Update(mousePos.x, mousePos.y, mouseWheel.x, mouseWheel.y, IsMouseButtonDown(.MOUSE_BUTTON_LEFT));
+    }
 
 	static void Render()
 	{
 		BeginDrawing();
 
 		ClearBackground(RAYWHITE);
+        ClayHomepage.Draw();
 
-		let mousePos = GetMousePosition();
-		let mouseWheel = GetMouseWheelMoveV();
-
-		ClayHomepage.Update(mousePos.x, mousePos.y, mouseWheel.x, mouseWheel.y, IsMouseButtonDown(.MouseButtonLeft));
+        DrawFPS(0,0);
 
 		EndDrawing();
 	}

--- a/example/src/Example.bf
+++ b/example/src/Example.bf
@@ -57,8 +57,6 @@ static class Example
 		ClearBackground(RAYWHITE);
         ClayHomepage.Draw();
 
-        DrawFPS(0,0);
-
 		EndDrawing();
 	}
 

--- a/example/src/renderers/Raylib.bf
+++ b/example/src/renderers/Raylib.bf
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Diagnostics;
+using Clay;
 
 using static RaylibBeef.Raylib;
 using static Clay.Clay;
@@ -9,32 +10,17 @@ namespace example;
 
 class RendererRaylib
 {
-	static Dictionary<uint16, RaylibBeef.Font> fonts =
-		new Dictionary<uint16, RaylibBeef.Font>() ~ delete _;
-
-	public static void LoadFont(uint16 fontId, uint16 fontSize, String path)
-	{
-		let font = LoadFontEx(path, fontSize, null, 0);
-		SetTextureFilter(font.texture, RaylibBeef.TextureFilter.TextureFilterTrilinear);
-		fonts.Add(fontId, font);
-	}
-
-	public static RaylibBeef.Font GetFont(uint16 fontId)
-	{
-		return fonts.GetValue(fontId);
-	}
-
 	public static RaylibBeef.Color ClayToRaylibColor(Color color)
 	{
 		return .((uint8)Math.Floor(color.r), (uint8)Math.Floor(color.g), (uint8)Math.Floor(color.b), (uint8)Math.Floor(color.a));
 	}
 
-	public static Dimensions MeasureText(StringSlice text, TextElementConfig* config, uint64* userData)
+	public static Dimensions MeasureText(StringSlice text, TextElementConfig* config, void* userData)
 	{
 		float maxTextWidth = 0;
 		float lineTextWidth = 0;
 		float textHeight = config.size;
-		RaylibBeef.Font fontToUse = RendererRaylib.GetFont(config.font);
+		RaylibBeef.Font fontToUse = FontManager.GetFont(config.font, config.size);
 
 		float scaleFactor = config.size / fontToUse.baseSize;
 
@@ -90,7 +76,8 @@ class RendererRaylib
 				}
 			case .Text:
 				let config = renderCommand.renderData.text;
-				let font = fonts.GetValue(config.fontId);
+				let font = FontManager.GetFont(config.fontId, config.fontSize);
+				//let font = fonts.GetValue(config.fontId);
 				let text = renderCommand.renderData.text.stringContents;
 
 				char8* chars = scope char8[text.length + 1]*;
@@ -100,6 +87,7 @@ class RendererRaylib
 				}
 
 				chars[text.length + 1] = '\0';
+
 
 				RaylibBeef.Raylib.DrawTextEx(
 					font,

--- a/example/src/samples/ClayHomepage.bf
+++ b/example/src/samples/ClayHomepage.bf
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Diagnostics;
+using Clay;
 
 using static RaylibBeef.Raylib;
 using static Clay.Clay;
@@ -9,22 +10,15 @@ namespace example;
 
 class ClayHomepage
 {
-	public enum FontId : uint16 : c_int
+	public enum FontId : uint16
 	{
-		case Title56 = 1;
-		case Title52 = 2;
-		case Title48 = 3;
-		case Title36 = 4;
-		case Title32 = 5;
-		case Body36 = 6;
-		case Body30 = 7;
-		case Body28 = 8;
-		case Body24 = 9;
-		case Body16 = 10;
-		case Body12 = 11;
+		case Title;
+		case Body;
 
 		public static implicit operator UnderlyingType(Self value);
 	}
+
+	static Clay.Clay.Array<Clay.Clay.RenderCommand> renderCommands;
 
 	const Color COLOR_BLACK = .(0, 0, 0, 255);
 	const Color COLOR_LIGHT = .(244, 235, 230, 255);
@@ -57,14 +51,14 @@ class ClayHomepage
 
 	static TextElementConfig headerTextConfig = .()
 		{
-			font = FontId.Body24,
+			font = FontId.Body,
 			size = 24,
 			color = .(61, 26, 5, 255)
 		};
 
 	static TextElementConfig blobTextConfig = .()
 		{
-			font = FontId.Body30,
+			font = FontId.Body,
 			size = 30,
 			color = .(244, 235, 230, 255)
 		};
@@ -94,17 +88,8 @@ class ClayHomepage
 
 	public static void Init()
 	{
-		RendererRaylib.LoadFont(FontId.Title56, 56, "resource/fonts/Calistoga-Regular.ttf");
-		RendererRaylib.LoadFont(FontId.Title52, 52, "resource/fonts/Calistoga-Regular.ttf");
-		RendererRaylib.LoadFont(FontId.Title48, 48, "resource/fonts/Calistoga-Regular.ttf");
-		RendererRaylib.LoadFont(FontId.Title36, 36, "resource/fonts/Calistoga-Regular.ttf");
-		RendererRaylib.LoadFont(FontId.Title32, 32, "resource/fonts/Calistoga-Regular.ttf");
-		RendererRaylib.LoadFont(FontId.Body36, 36, "resource/fonts/Quicksand-Semibold.ttf");
-		RendererRaylib.LoadFont(FontId.Body30, 30, "resource/fonts/Quicksand-Semibold.ttf");
-		RendererRaylib.LoadFont(FontId.Body28, 28, "resource/fonts/Quicksand-Semibold.ttf");
-		RendererRaylib.LoadFont(FontId.Body24, 24, "resource/fonts/Quicksand-Semibold.ttf");
-		RendererRaylib.LoadFont(FontId.Body16, 16, "resource/fonts/Quicksand-Semibold.ttf");
-		RendererRaylib.LoadFont(FontId.Body12, 32, "resource/fonts/Quicksand-Semibold.ttf");
+		FontManager.RegisterFont(FontId.Title, "resource/fonts/Calistoga-Regular.ttf", 32, 36, 48, 52, 56);
+		FontManager.RegisterFont(FontId.Body, "resource/fonts/Quicksand-Semibold.ttf", 16, 24, 28, 30, 32, 36);
 
 		Check1 = LoadTexture("resource/images/check_1.png");
 		Check2 = LoadTexture("resource/images/check_2.png");
@@ -121,6 +106,7 @@ class ClayHomepage
 		let arena = Clay_CreateArenaWithCapacityAndMemory(capacity, (uint8*)offset);
 
 		Clay_Initialize(arena, .(GetScreenWidth(), GetScreenHeight()), ErrorHandler( => OnError, null));
+
 		Clay_SetMeasureTextFunction( => RendererRaylib.MeasureText, null);
 	}
 
@@ -129,1251 +115,1309 @@ class ClayHomepage
 		Internal.StdFree(offset);
 	}
 
+	static bool mShowTimer = false;
+
 	static void LandingPageBlob(uint32 index, uint16 size, Color color, String text, RaylibBeef.Texture* image)
 	{
 #pragma format disable
-		UI(.() {
-			id = ID("HeroBlob", index),
-			layout = .() { 
-				alignment = ChildAlignment { x = .Left, y = .Center },
-				sizing = Sizing { width = Grow(0, 480) },
-				padding = Padding(16),
-				gap = 16
-			},
-			cornerRadius = CornerRadius(10),
-			border = .() {
-				width = .(2),
-				color = color
-			}
-		}, scope () => {
+	        
+
 			UI(.() {
-				id = ID("CheckImage", index),
-				layout = .() {  
-					sizing = .(Fixed(32), Fixed(32))
+				id = ID("HeroBlob", index),
+				layout = .() { 
+					alignment = ChildAlignment { x = .Left, y = .Center },
+					sizing = Sizing { width = Grow(0, 480) },
+					padding = Padding(16),
+					gap = 16
 				},
-				image = .() {
-					data = image,
-					dimensions = .(128, 128)
+				cornerRadius = CornerRadius(10),
+				border = .() {
+					width = .(2),
+					color = color
 				}
-			});
+			}, scope () => {
+				UI(.() {
+					id = ID("CheckImage", index),
+					layout = .() {  
+						sizing = .(Fixed(32), Fixed(32))
+					},
+					image = .() {
+						data = image,
+						dimensions = .(128, 128)
+					}
+				});
 
-			Text(text, .() { 
-				size = size, 
-				font = FontId.Body24,
-				color = color 
+	            
+
+				Text(text, .() { 
+					size = size, 
+					font = FontId.Body,
+					color = color 
+				});
 			});
-		});
 #pragma format restore
-	}
+		}
 
-	static void LandingPageDesktop()
-	{
-		let windowHeight = GetScreenHeight();
+		static void LandingPageDesktop()
+		{
+			let windowHeight = GetScreenHeight();
 
 #pragma format disable
-	    UI(.() {
-			id = ID("LandingPage1Desktop"), 
-			layout = .() { 
-				sizing = Sizing {
-					width = Percent(1),
-					height = Fixed(windowHeight - 70)
-				}, 
-				alignment = ChildAlignment {
-					y = .Center
-				},
-				padding = Padding(50, 50, 0, 0)
-			}
-		}, scope () => {
-			UI(.() {
-				id = ID("LandingPage1"), 
+		    UI(.() {
+				id = ID("LandingPage1Desktop"), 
 				layout = .() { 
-					sizing = Sizing { width = Percent(1), height = Percent(1) },
-					alignment = ChildAlignment { x = .Center, y = .Center },
-					padding = Padding(32),
-					direction = .LeftToRight,
-					gap = 32
-				}, 
-				border = .() {
-					width = .(2, 2, 0, 0, 0),
-					color = COLOR_RED
+					sizing = Sizing {
+						width = Percent(1),
+						height = Fixed(windowHeight - 70)
+					}, 
+					alignment = ChildAlignment {
+						y = .Center
+					},
+					padding = Padding(50, 50, 0, 0)
+				}
+			}, scope () => {
+				UI(.() {
+					id = ID("LandingPage1"), 
+					layout = .() { 
+						sizing = Sizing { width = Percent(1), height = Percent(1) },
+						alignment = ChildAlignment { x = .Center, y = .Center },
+						padding = Padding(32),
+						direction = .LeftToRight,
+						gap = 32
+					}, 
+					border = .() {
+						width = .(2, 2, 0, 0, 0),
+						color = COLOR_RED
+					}
+				}, scope () => {
+					UI(.() {
+						id = ID("LeftText"), 
+						layout = .() { 
+							sizing = Sizing { width = Percent(0.55f) }, 
+							gap = 8,
+							direction = .TopToBottom
+						}
+					}, scope () => {
+						Text("Clay is a flex-box style UI auto layout library in C, with declarative syntax and microsecond performance.", .() { 
+							size = 56, 
+							font = FontId.Title, 
+							color = COLOR_RED 
+						});
+
+						UI(.() {
+							id = ID("LandingPageSpacer"), 
+							layout = .() { 
+								sizing = .(GrowMin(1), Fixed(32)) 
+							}
+						});
+
+						Text("Clay is laying out this webpage right now!", .() { 
+							size = 36, 
+							font = FontId.Title, 
+							color = COLOR_ORANGE 
+						});
+					});
+
+					UI(.() {
+						id = ID("HeroImageOuter"), 
+						layout = .() { 
+							direction = .TopToBottom, 
+							sizing = Sizing { width = Percent(0.45f) }, 
+							alignment = ChildAlignment { x = .Center }, 
+							gap = 16 
+						}
+					}, scope () => {
+						LandingPageBlob(1, 32, COLOR_BLOB_BORDER_5, "High performance", &Check5);
+						LandingPageBlob(2, 32, COLOR_BLOB_BORDER_4, "Flexbox-style responsive layout", &Check4);
+						LandingPageBlob(3, 32, COLOR_BLOB_BORDER_3, "Declarative syntax", &Check3);
+						LandingPageBlob(4, 32, COLOR_BLOB_BORDER_2, "Single .h file for C/C++", &Check2);
+						LandingPageBlob(5, 32, COLOR_BLOB_BORDER_1, "Compile to 15kb .wasm", &Check1);
+					});
+				});
+			});
+#pragma format restore
+		}
+
+		static void LandingPageMobile()
+		{
+#pragma format disable
+			UI(.() {
+				id = ID("LandingPage1Mobile"), 
+				layout = .() {
+					direction = .TopToBottom, 
+					//sizing = { width = Sizing(0),
+					//height = Fit(min = windowHeight - 70) }, 
+					alignment = .(.Center, .Center),
+					padding = .(16, 16, 32, 32),
+					gap = 32 
 				}
 			}, scope () => {
 				UI(.() {
 					id = ID("LeftText"), 
-					layout = .() { 
-						sizing = Sizing { width = Percent(0.55f) }, 
-						gap = 8,
-						direction = .TopToBottom
+					layout = .() {
+						//sizing = .() { width = Sizing(0) }, 
+						direction = .TopToBottom,
+						gap = 8 
 					}
 				}, scope () => {
 					Text("Clay is a flex-box style UI auto layout library in C, with declarative syntax and microsecond performance.", .() { 
-						size = 56, 
-						font = FontId.Title56, 
-						color = COLOR_RED 
+						size = 48, 
+						font = FontId.Title,
+						color = COLOR_RED
 					});
 
 					UI(.() {
 						id = ID("LandingPageSpacer"), 
 						layout = .() { 
-							sizing = .(GrowMin(1), Fixed(32)) 
+							//sizing = .() { width = Sizing(0),height = Fixed(32) } 
 						}
 					});
 
 					Text("Clay is laying out this webpage right now!", .() { 
-						size = 36, 
-						font = FontId.Title36, 
-						color = COLOR_ORANGE 
+						size = 32, 
+						font = FontId.Title,color = COLOR_ORANGE 
 					});
 				});
 
 				UI(.() {
 					id = ID("HeroImageOuter"), 
-					layout = .() { 
+					layout = .() {
 						direction = .TopToBottom, 
-						sizing = Sizing { width = Percent(0.45f) }, 
-						alignment = ChildAlignment { x = .Center }, 
+						//sizing = { width = Sizing(0) }, 
+						alignment = .(.Center, .Top),
 						gap = 16 
 					}
 				}, scope () => {
-					LandingPageBlob(1, 32, COLOR_BLOB_BORDER_5, "High performance", &Check5);
-					LandingPageBlob(2, 32, COLOR_BLOB_BORDER_4, "Flexbox-style responsive layout", &Check4);
-					LandingPageBlob(3, 32, COLOR_BLOB_BORDER_3, "Declarative syntax", &Check3);
-					LandingPageBlob(4, 32, COLOR_BLOB_BORDER_2, "Single .h file for C/C++", &Check2);
-					LandingPageBlob(5, 32, COLOR_BLOB_BORDER_1, "Compile to 15kb .wasm", &Check1);
+					LandingPageBlob(1, 28, COLOR_BLOB_BORDER_5, "High performance", &Check5);
+					LandingPageBlob(2, 28, COLOR_BLOB_BORDER_4, "Flexbox-style responsive layout", &Check4);
+					LandingPageBlob(3, 28, COLOR_BLOB_BORDER_3, "Declarative syntax", &Check3);
+					LandingPageBlob(4, 28, COLOR_BLOB_BORDER_2, "Single .h file for C/C++", &Check2);
+					LandingPageBlob(5, 28, COLOR_BLOB_BORDER_1, "Compile to 15kb .wasm", &Check1);
 				});
 			});
-		});
 #pragma format restore
-	}
+		}
 
-	static void LandingPageMobile()
-	{
+		static void FeatureBlocksDesktop()
+		{
 #pragma format disable
-		UI(.() {
-			id = ID("LandingPage1Mobile"), 
-			layout = .() {
-				direction = .TopToBottom, 
-				//sizing = { width = Sizing(0),
-				//height = Fit(min = windowHeight - 70) }, 
-				alignment = .(.Center, .Center),
-				padding = .(16, 16, 32, 32),
-				gap = 32 
-			}
-		}, scope () => {
 			UI(.() {
-				id = ID("LeftText"), 
-				layout = .() {
-					//sizing = .() { width = Sizing(0) }, 
-					direction = .TopToBottom,
-					gap = 8 
-				}
-			}, scope () => {
-				Text("Clay is a flex-box style UI auto layout library in C, with declarative syntax and microsecond performance.", .() { 
-					size = 48, 
-					font = FontId.Title48,
-					color = COLOR_RED
-				});
-
-				UI(.() {
-					id = ID("LandingPageSpacer"), 
-					layout = .() { 
-						//sizing = .() { width = Sizing(0),height = Fixed(32) } 
-					}
-				});
-
-				Text("Clay is laying out this webpage right now!", .() { 
-					size = 32, 
-					font = FontId.Title36,color = COLOR_ORANGE 
-				});
-			});
-
-			UI(.() {
-				id = ID("HeroImageOuter"), 
-				layout = .() {
-					direction = .TopToBottom, 
-					//sizing = { width = Sizing(0) }, 
-					alignment = .(.Center, .Top),
-					gap = 16 
-				}
-			}, scope () => {
-				LandingPageBlob(1, 28, COLOR_BLOB_BORDER_5, "High performance", &Check5);
-				LandingPageBlob(2, 28, COLOR_BLOB_BORDER_4, "Flexbox-style responsive layout", &Check4);
-				LandingPageBlob(3, 28, COLOR_BLOB_BORDER_3, "Declarative syntax", &Check3);
-				LandingPageBlob(4, 28, COLOR_BLOB_BORDER_2, "Single .h file for C/C++", &Check2);
-				LandingPageBlob(5, 28, COLOR_BLOB_BORDER_1, "Compile to 15kb .wasm", &Check1);
-			});
-		});
-#pragma format restore
-	}
-
-	static void FeatureBlocksDesktop()
-	{
-#pragma format disable
-		UI(.() {
-			id = ID("FeatureBlocksOuter"), 
-			layout = .() { 
-				sizing = .(Grow(0, 0), Grow(0, 0))
-			}
-		}, scope () => {
-			UI(.() {
-				id = ID("FeatureBlocksInner"), 
+				id = ID("FeatureBlocksOuter"), 
 				layout = .() { 
-					sizing = .(Grow(0, 0), Grow(0, 0)),
-					alignment = .(0, .Center)
-				},
-				border = .() {
-					width = BorderWidth { betweenChildren = 2 },
-					color = COLOR_RED
+					sizing = .(Grow(0, 0), Grow(0, 0))
 				}
-			}, scope() => {
-
-				let textConfig = TextElementConfig { 
-					size = 24, 
-					font = FontId.Body24, 
-					color = COLOR_RED 
-				};
-
+			}, scope () => {
 				UI(.() {
-					id = ID("HFileBoxOuter"), 
-					layout = .() { direction = .TopToBottom, 
-						sizing = Sizing { width = Percent(0.5f) },
-						alignment = .(0, .Center),
-						padding = .(50, 50, 32, 32), 
-						gap = 8
+					id = ID("FeatureBlocksInner"), 
+					layout = .() { 
+						sizing = .(Grow(0, 0), Grow(0, 0)),
+						alignment = .(0, .Center)
+					},
+					border = .() {
+						width = BorderWidth { betweenChildren = 2 },
+						color = COLOR_RED
 					}
-				}, scope () => {
-					UI(.() {
-						id = ID("HFileIncludeOuter"), 
-						layout = .() {
-							padding = .(8, 8, 4, 4)
-						},
-						backgroundColor = COLOR_RED,
-						cornerRadius = CornerRadius(8)
-					}, scope () => {
-						Text("#include clay.h", .() { 
-							size = 24, 
-							font = FontId.Body24, 
-							color = COLOR_LIGHT 
-						});
-					});
+				}, scope() => {
 
-					Text("~2000 lines of C99.", textConfig);
-
-					Text("Zero dependencies, including no C standard library.", textConfig);
-				});
-
-				UI(.() {
-					id = ID("BringYourOwnRendererOuter"), 
-					layout = .() { direction = .TopToBottom, 
-						sizing = Sizing { width = Percent(0.5f) },
-						alignment = .(0, .Center), 
-						padding = .(50, 50, 32, 32), 
-						gap = 8
-					}
-				}, scope () => {
-					Text("Renderer agnostic.", .() {
-						font = FontId.Body24, 
+					let textConfig = TextElementConfig { 
 						size = 24, 
-						color = COLOR_ORANGE 
+						font = FontId.Body, 
+						color = COLOR_RED 
+					};
+
+					UI(.() {
+						id = ID("HFileBoxOuter"), 
+						layout = .() { direction = .TopToBottom, 
+							sizing = Sizing { width = Percent(0.5f) },
+							alignment = .(0, .Center),
+							padding = .(50, 50, 32, 32), 
+							gap = 8
+						}
+					}, scope () => {
+						UI(.() {
+							id = ID("HFileIncludeOuter"), 
+							layout = .() {
+								padding = .(8, 8, 4, 4)
+							},
+							backgroundColor = COLOR_RED,
+							cornerRadius = CornerRadius(8)
+						}, scope () => {
+							Text("#include clay.h", .() { 
+								size = 24, 
+								font = FontId.Body, 
+								color = COLOR_LIGHT 
+							});
+						});
+
+						Text("~2000 lines of C99.", textConfig);
+
+						Text("Zero dependencies, including no C standard library.", textConfig);
 					});
 
-					Text("Layout with clay, then render with Raylib, WebGL Canvas or even as HTML.", textConfig);
+					UI(.() {
+						id = ID("BringYourOwnRendererOuter"), 
+						layout = .() { direction = .TopToBottom, 
+							sizing = Sizing { width = Percent(0.5f) },
+							alignment = .(0, .Center), 
+							padding = .(50, 50, 32, 32), 
+							gap = 8
+						}
+					}, scope () => {
+						Text("Renderer agnostic.", .() {
+							font = FontId.Body, 
+							size = 24, 
+							color = COLOR_ORANGE 
+						});
 
-					Text("Flexible output for easy compositing in your custom engine or environment.", textConfig);
+						Text("Layout with clay, then render with Raylib, WebGL Canvas or even as HTML.", textConfig);
+
+						Text("Flexible output for easy compositing in your custom engine or environment.", textConfig);
+					});
 				});
 			});
-		});
 #pragma format restore
-	}
+		}
 
-	static void FeatureBlocksMobile()
-	{
+		static void FeatureBlocksMobile()
+		{
 #pragma format disable
-//		/*UI(.() {
-//			id = ID("FeatureBlocksInner"), 
-//			layout = .() { direction = .TopToBottom, 
-//		sizing = { Sizing(0) } 
-//		}, 
-//		border = { 
-//			betweenChildren = { width = 2, 
-//			color = COLOR_RED } 
-//			})) {
-//			TextElementConfig *textConfig = TextConfig({ 
-//				size = 24, 
-//				font = FontId.Body24, 
-//				color = COLOR_RED 
-//			});
-//			UI(.() {
-//				id = ID("HFileBoxOuter"), 
-//				layout = .() { direction = .TopToBottom, 
-//			sizing = { Sizing(0) }, 
-//			alignment = {0, .AlignYCenter}, 
-//			padding = {16, 16, 32, 32}, 
-//			gap = 8 
-//			})) {
-//				UI(.() {
-//					id = ID("HFileIncludeOuter"), 
-//					layout = .() { padding = {8, 4} 
-//				}, Rectangle({ color = COLOR_RED, cornerRadius = CLAY_CORNER_RADIUS(8) 
-//				})) {
-//					Text("#include clay.h", .() { 
-//						size = 24, 
-//						font = FontId.Body24, 
-//						color = COLOR_LIGHT 
-//					}));
-//				}
-//				Text("~2000 lines of C99.", textConfig);
-//				Text("Zero dependencies, including no C standard library.", textConfig);
-//			}
-//			UI(.() {
-//				id = ID("BringYourOwnRendererOuter"), 
-//				layout = .() { direction = .TopToBottom, 
-//			sizing = { Sizing(0) }, 
-//			alignment = {0, .AlignYCenter}, 
-//			padding = {16, 16, 32, 32}, 
-//			gap = 8 
-//			})) {
-//				Text("Renderer agnostic.", .() { font = FontId.Body24, 
-//				size = 24, 
-//				color = COLOR_ORANGE 
-//				}));
-//				Text("Layout with clay, then render with Raylib, WebGL Canvas or even as HTML.", textConfig);
-//				Text("Flexible output for easy compositing in your custom engine or environment.", textConfig);
-//			}
-//		}*/
+	//		/*UI(.() {
+	//			id = ID("FeatureBlocksInner"), 
+	//			layout = .() { direction = .TopToBottom, 
+	//		sizing = { Sizing(0) } 
+	//		}, 
+	//		border = { 
+	//			betweenChildren = { width = 2, 
+	//			color = COLOR_RED } 
+	//			})) {
+	//			TextElementConfig *textConfig = TextConfig({ 
+	//				size = 24, 
+	//				font = FontId.Body, 
+	//				color = COLOR_RED 
+	//			});
+	//			UI(.() {
+	//				id = ID("HFileBoxOuter"), 
+	//				layout = .() { direction = .TopToBottom, 
+	//			sizing = { Sizing(0) }, 
+	//			alignment = {0, .AlignYCenter}, 
+	//			padding = {16, 16, 32, 32}, 
+	//			gap = 8 
+	//			})) {
+	//				UI(.() {
+	//					id = ID("HFileIncludeOuter"), 
+	//					layout = .() { padding = {8, 4} 
+	//				}, Rectangle({ color = COLOR_RED, cornerRadius = CLAY_CORNER_RADIUS(8) 
+	//				})) {
+	//					Text("#include clay.h", .() { 
+	//						size = 24, 
+	//						font = FontId.Body, 
+	//						color = COLOR_LIGHT 
+	//					}));
+	//				}
+	//				Text("~2000 lines of C99.", textConfig);
+	//				Text("Zero dependencies, including no C standard library.", textConfig);
+	//			}
+	//			UI(.() {
+	//				id = ID("BringYourOwnRendererOuter"), 
+	//				layout = .() { direction = .TopToBottom, 
+	//			sizing = { Sizing(0) }, 
+	//			alignment = {0, .AlignYCenter}, 
+	//			padding = {16, 16, 32, 32}, 
+	//			gap = 8 
+	//			})) {
+	//				Text("Renderer agnostic.", .() { font = FontId.Body, 
+	//				size = 24, 
+	//				color = COLOR_ORANGE 
+	//				}));
+	//				Text("Layout with clay, then render with Raylib, WebGL Canvas or even as HTML.", textConfig);
+	//				Text("Flexible output for easy compositing in your custom engine or environment.", textConfig);
+	//			}
+	//		}*/
 #pragma format restore
-	}
+		}
 
-	static void DeclarativeSyntaxPageDesktop()
-	{
+		static void DeclarativeSyntaxPageDesktop()
+		{
 #pragma format disable
-		UI(.() {
-			id = ID("SyntaxPageDesktop"), 
-			layout = .() { 
-				sizing = Sizing {
-					width = Percent(1),
-					height = FitMin(GetScreenHeight() - 50)
-				}, 
-				alignment = .(0, .Center),
-				padding = .(50, 50, 0, 0)
-			}
-		}, scope () => {
 			UI(.() {
-				id = ID("SyntaxPage"), 
+				id = ID("SyntaxPageDesktop"), 
 				layout = .() { 
 					sizing = Sizing {
 						width = Percent(1),
-						height = Percent(1)
-					},
-					alignment = .(0, .Center), 
-					padding = Padding(32),
-					gap = 32
-				},
-				border = .() {
-					width = .(2, 2, 0, 0, 0),
-					color = COLOR_RED
+						height = FitMin(GetScreenHeight() - 50)
+					}, 
+					alignment = .(0, .Center),
+					padding = .(50, 50, 0, 0)
 				}
 			}, scope () => {
 				UI(.() {
-					id = ID("SyntaxPageLeftText"), 
-					layout = .() {
+					id = ID("SyntaxPage"), 
+					layout = .() { 
 						sizing = Sizing {
-							width = Percent(0.5f)
+							width = Percent(1),
+							height = Percent(1)
 						},
-						direction = .TopToBottom,
-						gap = 8
+						alignment = .(0, .Center), 
+						padding = Padding(32),
+						gap = 32
+					},
+					border = .() {
+						width = .(2, 2, 0, 0, 0),
+						color = COLOR_RED
 					}
 				}, scope () => {
-					Text("Declarative Syntax", .() { 
-						size = 56, 
-						font = FontId.Title56, 
-						color = COLOR_RED 
+					UI(.() {
+						id = ID("SyntaxPageLeftText"), 
+						layout = .() {
+							sizing = Sizing {
+								width = Percent(0.5f)
+							},
+							direction = .TopToBottom,
+							gap = 8
+						}
+					}, scope () => {
+						Text("Declarative Syntax", .() { 
+							size = 56, 
+							font = FontId.Title, 
+							color = COLOR_RED 
+						});
+
+						UI(.() {
+							id = ID("SyntaxSpacer"), 
+							layout = .() { 
+								//sizing = { Sizing(max = 16) } 
+							}
+						});
+
+						Text("Flexible and readable declarative syntax with nested UI element hierarchies.", .() { 
+							size = 28, 
+							font = FontId.Body, 
+							color = COLOR_RED 
+						});
+
+						Text("Mix elements with standard C code like loops, conditionals and functions.", .() { 
+							size = 28, 
+							font = FontId.Body, 
+							color = COLOR_RED 
+						});
+
+						Text("Create your own library of re-usable components from UI primitives like text, images and rectangles.", .() { 
+							size = 28, 
+							font = FontId.Body, 
+							color = COLOR_RED 
+						});
 					});
 
 					UI(.() {
-						id = ID("SyntaxSpacer"), 
+						id = ID("SyntaxPageRightImage"), 
 						layout = .() { 
-							//sizing = { Sizing(max = 16) } 
+							sizing = Sizing {
+								width = Percent(0.50f)
+							}, 
+							alignment = ChildAlignment { x = .Center } 
 						}
+					}, scope () => {
+						UI(.() {
+							id = ID("SyntaxPageRightImageInner"), 
+							layout = .() { 
+								sizing = Sizing {
+									width = GrowMax(568)
+								} 
+							},
+							image = .() {
+								dimensions = .(1136, 1194),
+								data = &Declarative
+							}
+						});
+					});
+				});
+			});
+#pragma format restore
+		}
+
+		static void DeclarativeSyntaxPageMobile()
+		{
+#pragma format disable
+	//		/*UI(.() {
+	//			id = ID("SyntaxPageDesktop"), 
+	//			layout = .() { direction = .TopToBottom, 
+	//		sizing = { Sizing(0), Fit(min = windowHeight - 50) }, 
+	//		alignment = {.Center, .AlignYCenter}, 
+	//		padding = {16, 16, 32, 32}, 
+	//		gap = 16 
+	//		})) {
+	//			UI(.() {
+	//				id = ID("SyntaxPageLeftText"), 
+	//				layout = .() { 
+	//				sizing = { Sizing(0) }, 
+	//			direction = .TopToBottom, 
+	//			gap = 8 
+	//			})) {
+	//				Text("Declarative Syntax", .() { 
+	//					size = 48, 
+	//					font = Font.Title56, 
+	//					color = COLOR_RED 
+	//				}));
+	//				UI(.() {
+	//					id = ID("SyntaxSpacer"), 
+	//					layout = .() { 
+	//					sizing = { Sizing(.max = 16) } 
+	//				})) {}
+	//				Text("Flexible and readable declarative syntax with nested UI element hierarchies.", .() { 
+	//					size = 28, 
+	//					font = Font.Body36, 
+	//					color = COLOR_RED 
+	//				}));
+	//				Text("Mix elements with standard C code like loops, conditionals and functions.", .() { 
+	//					size = 28, 
+	//					font = Font.Body36, 
+	//					color = COLOR_RED 
+	//				}));
+	//				Text("Create your own library of re-usable components from UI primitives like text, images and rectangles.", .() { 
+	//					size = 28, 
+	//					font = Font.Body36, 
+	//					color = COLOR_RED 
+	//				}));
+	//			}
+	//			UI(.() {
+	//				id = ID("SyntaxPageRightImage"), 
+	//				layout = .() { 
+	//				sizing = { Sizing(0) }, 
+	//			alignment = {.x = .Center} 
+	//			})) {
+	//				UI(.() {
+	//					id = ID("SyntaxPageRightImageInner"), 
+	//					layout = .() { 
+	//					sizing = { Sizing(.max = 568) } 
+	//					}, Image({ 
+	//						sourceDimensions = {1136, 1194}, 
+	//					sourceURL = "/clay/images/declarative.png" } )) {}
+	//			}
+	//		}*/
+#pragma format restore
+		}
+
+		public static Color ColorLerp(Color a, Color b, float amount)
+		{
+			return .(
+				a.r + (b.r - a.r) * amount,
+				a.g + (b.g - a.g) * amount,
+				a.b + (b.b - a.b) * amount,
+				a.a + (b.a - a.a) * amount
+				);
+		}
+
+		static void HighPerformancePageDesktop(float lerpValue)
+		{
+#pragma format disable
+			UI(.() {
+				id = ID("PerformanceOuter"), 
+				layout = .() { 
+					sizing = Sizing {
+						width = Grow(0, 0),
+						height = FitMin(GetScreenHeight() - 50)
+					}, 
+					alignment = .(0, .Center), 
+					padding = .(82, 82, 32, 32), 
+					gap = 64
+				},
+				backgroundColor = COLOR_RED
+			}, scope() => {
+				UI(.() {
+					id = ID("PerformanceLeftText"), 
+					layout = .() { 
+						sizing = Sizing {
+							width = Percent(0.50f)
+						},
+						direction = .TopToBottom, 
+						gap = 8
+					}
+				}, scope () => {
+					Text("High Performance", .() { 
+						size = 52, 
+						font = FontId.Title, 
+						color = COLOR_LIGHT 
 					});
 
-					Text("Flexible and readable declarative syntax with nested UI element hierarchies.", .() { 
+					Text("Fast enough to recompute your entire UI every frame.", .() { 
 						size = 28, 
-						font = FontId.Body36, 
-						color = COLOR_RED 
+						font = FontId.Body, 
+						color = COLOR_LIGHT 
 					});
 
-					Text("Mix elements with standard C code like loops, conditionals and functions.", .() { 
+					Text("Small memory footprint (3.5mb default with static allocation & reuse. No malloc / free.", .() { 
 						size = 28, 
-						font = FontId.Body36, 
-						color = COLOR_RED 
+						font = FontId.Body, 
+						color = COLOR_LIGHT 
 					});
 
-					Text("Create your own library of re-usable components from UI primitives like text, images and rectangles.", .() { 
+					Text("Simplify animations and reactive UI design by avoiding the standard performance hacks.", .() { 
 						size = 28, 
-						font = FontId.Body36, 
-						color = COLOR_RED 
+						font = FontId.Body, 
+						color = COLOR_LIGHT 
 					});
 				});
 
+				String LOREM_IPSUM_TEXT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+
 				UI(.() {
-					id = ID("SyntaxPageRightImage"), 
+					id = ID("PerformanceRightImageOuter"), 
 					layout = .() { 
 						sizing = Sizing {
 							width = Percent(0.50f)
 						}, 
-						alignment = ChildAlignment { x = .Center } 
-					}
-				}, scope () => {
-					UI(.() {
-						id = ID("SyntaxPageRightImageInner"), 
-						layout = .() { 
-							sizing = Sizing {
-								width = GrowMax(568)
-							} 
-						},
-						image = .() {
-							dimensions = .(1136, 1194),
-							data = &Declarative
-						}
-					});
-				});
-			});
-		});
-#pragma format restore
-	}
-
-	static void DeclarativeSyntaxPageMobile()
-	{
-#pragma format disable
-//		/*UI(.() {
-//			id = ID("SyntaxPageDesktop"), 
-//			layout = .() { direction = .TopToBottom, 
-//		sizing = { Sizing(0), Fit(min = windowHeight - 50) }, 
-//		alignment = {.Center, .AlignYCenter}, 
-//		padding = {16, 16, 32, 32}, 
-//		gap = 16 
-//		})) {
-//			UI(.() {
-//				id = ID("SyntaxPageLeftText"), 
-//				layout = .() { 
-//				sizing = { Sizing(0) }, 
-//			direction = .TopToBottom, 
-//			gap = 8 
-//			})) {
-//				Text("Declarative Syntax", .() { 
-//					size = 48, 
-//					font = Font.Title56, 
-//					color = COLOR_RED 
-//				}));
-//				UI(.() {
-//					id = ID("SyntaxSpacer"), 
-//					layout = .() { 
-//					sizing = { Sizing(.max = 16) } 
-//				})) {}
-//				Text("Flexible and readable declarative syntax with nested UI element hierarchies.", .() { 
-//					size = 28, 
-//					font = Font.Body36, 
-//					color = COLOR_RED 
-//				}));
-//				Text("Mix elements with standard C code like loops, conditionals and functions.", .() { 
-//					size = 28, 
-//					font = Font.Body36, 
-//					color = COLOR_RED 
-//				}));
-//				Text("Create your own library of re-usable components from UI primitives like text, images and rectangles.", .() { 
-//					size = 28, 
-//					font = Font.Body36, 
-//					color = COLOR_RED 
-//				}));
-//			}
-//			UI(.() {
-//				id = ID("SyntaxPageRightImage"), 
-//				layout = .() { 
-//				sizing = { Sizing(0) }, 
-//			alignment = {.x = .Center} 
-//			})) {
-//				UI(.() {
-//					id = ID("SyntaxPageRightImageInner"), 
-//					layout = .() { 
-//					sizing = { Sizing(.max = 568) } 
-//					}, Image({ 
-//						sourceDimensions = {1136, 1194}, 
-//					sourceURL = "/clay/images/declarative.png" } )) {}
-//			}
-//		}*/
-#pragma format restore
-	}
-
-	public static Color ColorLerp(Color a, Color b, float amount)
-	{
-		return .(
-			a.r + (b.r - a.r) * amount,
-			a.g + (b.g - a.g) * amount,
-			a.b + (b.b - a.b) * amount,
-			a.a + (b.a - a.a) * amount
-			);
-	}
-
-	static void HighPerformancePageDesktop(float lerpValue)
-	{
-#pragma format disable
-		UI(.() {
-			id = ID("PerformanceOuter"), 
-			layout = .() { 
-				sizing = Sizing {
-					width = Grow(0, 0),
-					height = FitMin(GetScreenHeight() - 50)
-				}, 
-				alignment = .(0, .Center), 
-				padding = .(82, 82, 32, 32), 
-				gap = 64
-			},
-			backgroundColor = COLOR_RED
-		}, scope() => {
-			UI(.() {
-				id = ID("PerformanceLeftText"), 
-				layout = .() { 
-					sizing = Sizing {
-						width = Percent(0.50f)
-					},
-					direction = .TopToBottom, 
-					gap = 8
-				}
-			}, scope () => {
-				Text("High Performance", .() { 
-					size = 52, 
-					font = FontId.Title56, 
-					color = COLOR_LIGHT 
-				});
-
-				Text("Fast enough to recompute your entire UI every frame.", .() { 
-					size = 28, 
-					font = FontId.Body28, 
-					color = COLOR_LIGHT 
-				});
-
-				Text("Small memory footprint (3.5mb default with static allocation & reuse. No malloc / free.", .() { 
-					size = 28, 
-					font = FontId.Body28, 
-					color = COLOR_LIGHT 
-				});
-
-				Text("Simplify animations and reactive UI design by avoiding the standard performance hacks.", .() { 
-					size = 28, 
-					font = FontId.Body28, 
-					color = COLOR_LIGHT 
-				});
-			});
-
-			String LOREM_IPSUM_TEXT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
-
-			UI(.() {
-				id = ID("PerformanceRightImageOuter"), 
-				layout = .() { 
-					sizing = Sizing {
-						width = Percent(0.50f)
-					}, 
-					alignment = .(.Center, 0)
-				},
-				border = .(2, COLOR_LIGHT)
-			}, scope () => {
-				UI(.() {
-					layout = .() { 
-						sizing = .(GrowMin(0), Fixed(400))
-					},
-					backgroundColor = COLOR_LIGHT 
-				}, scope() => {
-					UI(.() {
-						id = ID("AnimationDemoContainerLeft"), 
-						layout = .() { 
-							sizing = .(Percent(0.3f + 0.4f * lerpValue), GrowMin(0)),
-							alignment = .(0, .Center), 
-							padding = Padding(32) 
-						},
-						backgroundColor = ColorLerp(COLOR_RED, COLOR_ORANGE, lerpValue)
-					}, scope () => {
-						Text(LOREM_IPSUM_TEXT, .() { 
-							size = 24, 
-							font = FontId.Body24, 
-							color = COLOR_LIGHT 
-						});
-					});
-
-					UI(.() {
-						id = ID("AnimationDemoContainerRight"), 
-						layout = .() { 
-							sizing = Sizing(GrowMin(0), GrowMin(0)),
-							alignment = .(0, .Center),
-							padding = Padding(32)
-						},
-						backgroundColor = ColorLerp(COLOR_ORANGE, COLOR_RED, lerpValue)
-					}, scope () => {
-						Text(LOREM_IPSUM_TEXT, .() { 
-							size = 24, 
-							font = FontId.Body24, 
-							color = COLOR_LIGHT 
-						});
-					});
-				});
-			});
-		});
-#pragma format restore
-	}
-
-	static void HighPerformancePageMobile(float lerpValue)
-	{
-#pragma format disable
-		UI(.() {
-			id = ID("PerformanceOuter"),
-			layout = .() {
-				direction = .TopToBottom,
-				sizing = Sizing {
-					width = GrowMin(0),
-					height = FitMin(GetScreenHeight() - 50)
-				},
-				alignment = .(.Center, .Center),
-				padding = .(16, 16, 32, 32),
-				gap = 32
-			},
-			backgroundColor = COLOR_RED
-		}, scope () => {
-			UI(.() {
-				id = ID("PerformanceLeftText"),
-				layout = .() {
-					//sizing = { Sizing(0) },
-					direction = .TopToBottom,
-					gap = 8
-				}
-			}, scope () => {
-				Text("High Performance", .() {
-					size = 48,
-					font = FontId.Title56,
-					color = COLOR_LIGHT
-				});
-
-				UI(.() {
-					id = ID("PerformanceSpacer"),
-					layout = .() {
-						//sizing = { Sizing(.max = 16) }
-					}
-				});
-
-				Text("Fast enough to recompute your entire UI every frame.", .() {
-					size = 28,
-					font = FontId.Body36,
-					color = COLOR_LIGHT
-				});
-
-				Text("Small memory footprint (3.5mb default with static allocation & reuse. No malloc / free.", .() {
-					size = 28,
-					font = FontId.Body36,
-					color = COLOR_LIGHT
-				});
-				Text("Simplify animations and reactive UI design by avoiding the standard performance hacks.", .() {
-					size = 28,
-					font = FontId.Body36,
-					color = COLOR_LIGHT
-				});
-			});
-
-			String LOREM_IPSUM_TEXT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
-
-			UI(.() {
-				id = ID("PerformanceRightImageOuter"),
-				layout = .() {
-					sizing = .(Grow(0,0),Grow(0,0)),
-					alignment = .(.Center, .Center)
-				},
-				backgroundColor = COLOR_BLACK
-			}, scope () => {
-				UI(.() {
-					id = ID(""),
-					layout = .() { 
-						sizing = Sizing { height = Fixed(400) }
+						alignment = .(.Center, 0)
 					},
 					border = .(2, COLOR_LIGHT)
 				}, scope () => {
 					UI(.() {
-						id = ID("AnimationDemoContainerLeft"),
-						layout = .() {
-							sizing = .(Percent(0.35f + 0.3f * lerpValue), GrowMin(0)),
-							alignment = ChildAlignment { y = .Center },
-							padding = Padding(16)
-						},
-						backgroundColor = ColorLerp(COLOR_RED, COLOR_ORANGE, lerpValue)
-					}, scope () => {
-						Text(LOREM_IPSUM_TEXT, .() {
-							size = 24,
-							font = FontId.Title56,
-							color = COLOR_LIGHT
-						});
-					});
-
-					UI(.() {
-						id = ID("AnimationDemoContainerRight"), 
 						layout = .() { 
-							sizing = .(Grow(0, 0), Grow(0, 0)), 
-							alignment = ChildAlignment { y = .Center }, 
-							padding = Padding(16) 
-						}
-						//backgroundColor = ColorLerp(COLOR_ORANGE, COLOR_RED, lerpValue)
-					}, scope () => {
-						Text(LOREM_IPSUM_TEXT, .() { 
-							size = 24, 
-							font = FontId.Title56, 
-							color = COLOR_LIGHT 
+							sizing = .(GrowMin(0), Fixed(400))
+						},
+						backgroundColor = COLOR_LIGHT 
+					}, scope() => {
+						UI(.() {
+							id = ID("AnimationDemoContainerLeft"), 
+							layout = .() { 
+								sizing = .(Percent(0.3f + 0.4f * lerpValue), GrowMin(0)),
+								alignment = .(0, .Center), 
+								padding = Padding(32) 
+							},
+							backgroundColor = ColorLerp(COLOR_RED, COLOR_ORANGE, lerpValue)
+						}, scope () => {
+							Text(LOREM_IPSUM_TEXT, .() { 
+								size = 24, 
+								font = FontId.Body, 
+								color = COLOR_LIGHT 
+							});
+						});
+
+						UI(.() {
+							id = ID("AnimationDemoContainerRight"), 
+							layout = .() { 
+								sizing = Sizing(GrowMin(0), GrowMin(0)),
+								alignment = .(0, .Center),
+								padding = Padding(32)
+							},
+							backgroundColor = ColorLerp(COLOR_ORANGE, COLOR_RED, lerpValue)
+						}, scope () => {
+							Text(LOREM_IPSUM_TEXT, .() { 
+								size = 24, 
+								font = FontId.Body, 
+								color = COLOR_LIGHT 
+							});
 						});
 					});
 				});
 			});
-		});
 #pragma format restore
-	}
+		}
 
-	static void HandleRendererButtonInteraction(ElementId elementId, PointerData pointerInfo, uint64* userData)
-	{
+		static void HighPerformancePageMobile(float lerpValue)
+		{
 #pragma format disable
-//		if (pointerInfo.state == .ClayPointerDataPressedThisFrame) {
-//			//sActiveRendererIndex = (.)userData;
-//			//Clay_SetCullingEnabled(sActiveRendererIndex == 1);
-//			//Clay_SetExternalScrollHandlingEnabled(sActiveRendererIndex == 0);
-//		}
-#pragma format restore
-	}
-
-	public static bool Clay_Hovered()
-	{
-		return false;
-	}
-
-	static void RendererButtonActive(String text)
-	{
-#pragma format disable
-		UI(.() {
-			layout = .(){
-				sizing = Sizing { width = Fixed(300) },
-				padding = Padding(16)
-			},
-			backgroundColor = Clay_Hovered() ? COLOR_RED_HOVER : COLOR_RED,
-			cornerRadius = CornerRadius(10)
-		}, scope () => {
-			Text(text, .() {
-				disablePointerEvents = true,
-				size = 28,
-				font = FontId.Body36,
-				color = COLOR_LIGHT
-			});
-		});
-#pragma format restore
-	}
-
-	static void RendererButtonInactive(String text, int64 rendererIndex)
-	{
-#pragma format disable
-		UI(.() {
-			layout = .() { 
-				sizing = Sizing {
-					width = Fixed(300)
-				}, 
-				padding = Padding(16) 
-			},
-			backgroundColor = Clay_Hovered() ? COLOR_LIGHT_HOVER : COLOR_LIGHT,
-			cornerRadius = CornerRadius(10),
-			border = .(2, COLOR_RED)
-			//Clay_OnHover(HandleRendererButtonInteraction, rendererIndex)
-		}, scope () => {
-			Text(text, .() {
-				//disablePointerEvents = true, 
-				size = 28, 
-				font = FontId.Body36, 
-				color = COLOR_RED 
-			});
-		});
-#pragma format restore
-	}
-
-	static void RendererPageDesktop()
-	{
-#pragma format disable
-		UI(.() {
-			id = ID("RendererPageDesktop"), 
-			layout = .() { 
-				sizing = .(GrowMin(0), FitMin(GetScreenHeight() - 50)), 
-				alignment = .(0, .Center),  
-				padding = .(50, 0)
-			}
-		}, scope () => {
 			UI(.() {
-				id = ID("RendererPage"), 
-				layout = .() { 
-					sizing = .(GrowMin(0), GrowMin(0)),  
-					alignment = .(.Center, .Center), 
-					padding = Padding(32),
-					gap = 32 
-				}, 
-				border = .() {
-					width = .(2, 2, 0, 0, 0),
-					color = COLOR_RED
-				}
+				id = ID("PerformanceOuter"),
+				layout = .() {
+					direction = .TopToBottom,
+					sizing = Sizing {
+						width = GrowMin(0),
+						height = FitMin(GetScreenHeight() - 50)
+					},
+					alignment = .(.Center, .Center),
+					padding = .(16, 16, 32, 32),
+					gap = 32
+				},
+				backgroundColor = COLOR_RED
 			}, scope () => {
 				UI(.() {
-					id = ID("RendererLeftText"), 
-					layout = .() { 
-						sizing = Sizing { width = Percent(0.5f) },
-						direction = .TopToBottom, 
+					id = ID("PerformanceLeftText"),
+					layout = .() {
+						//sizing = { Sizing(0) },
+						direction = .TopToBottom,
 						gap = 8
 					}
 				}, scope () => {
-					Text("Renderer & Platform Agnostic", .() { 
-						size = 52, 
-						font = FontId.Title52, 
-						color = COLOR_RED 
+					Text("High Performance", .() {
+						size = 48,
+						font = FontId.Title,
+						color = COLOR_LIGHT
 					});
 
 					UI(.() {
-						id = ID("RendererSpacerLeft"), 
-						layout = .() { 
-							sizing = Sizing { height = Fixed(16) }
+						id = ID("PerformanceSpacer"),
+						layout = .() {
+							//sizing = { Sizing(.max = 16) }
 						}
 					});
 
-					Text("Clay outputs a sorted array of primitive render commands, such as RECTANGLE, TEXT or IMAGE.", .() { 
-						size = 28, 
-						font = FontId.Body28, 
-						color = COLOR_RED 
+					Text("Fast enough to recompute your entire UI every frame.", .() {
+						size = 28,
+						font = FontId.Body,
+						color = COLOR_LIGHT
 					});
 
-					Text("Write your own renderer in a few hundred lines of code, or use the provided examples for Raylib, WebGL canvas and more.", .() { 
-						size = 28, 
-						font = FontId.Body28, 
-						color = COLOR_RED 
+					Text("Small memory footprint (3.5mb default with static allocation & reuse. No malloc / free.", .() {
+						size = 28,
+						font = FontId.Body,
+						color = COLOR_LIGHT
 					});
-
-					Text("There's even an HTML renderer - you're looking at it right now!", .() { 
-						size = 28, 
-						font = FontId.Body28, 
-						color = COLOR_RED 
+					Text("Simplify animations and reactive UI design by avoiding the standard performance hacks.", .() {
+						size = 28,
+						font = FontId.Body,
+						color = COLOR_LIGHT
 					});
 				});
 
+				String LOREM_IPSUM_TEXT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+
 				UI(.() {
-					id = ID("RendererRightText"), 
+					id = ID("PerformanceRightImageOuter"),
+					layout = .() {
+						sizing = .(Grow(0,0),Grow(0,0)),
+						alignment = .(.Center, .Center)
+					},
+					backgroundColor = COLOR_BLACK
+				}, scope () => {
+					UI(.() {
+						id = ID(""),
+						layout = .() { 
+							sizing = Sizing { height = Fixed(400) }
+						},
+						border = .(2, COLOR_LIGHT)
+					}, scope () => {
+						UI(.() {
+							id = ID("AnimationDemoContainerLeft"),
+							layout = .() {
+								sizing = .(Percent(0.35f + 0.3f * lerpValue), GrowMin(0)),
+								alignment = ChildAlignment { y = .Center },
+								padding = Padding(16)
+							},
+							backgroundColor = ColorLerp(COLOR_RED, COLOR_ORANGE, lerpValue)
+						}, scope () => {
+							Text(LOREM_IPSUM_TEXT, .() {
+								size = 24,
+								font = FontId.Title,
+								color = COLOR_LIGHT
+							});
+						});
+
+						UI(.() {
+							id = ID("AnimationDemoContainerRight"), 
+							layout = .() { 
+								sizing = .(Grow(0, 0), Grow(0, 0)), 
+								alignment = ChildAlignment { y = .Center }, 
+								padding = Padding(16) 
+							}
+							//backgroundColor = ColorLerp(COLOR_ORANGE, COLOR_RED, lerpValue)
+						}, scope () => {
+							Text(LOREM_IPSUM_TEXT, .() { 
+								size = 24, 
+								font = FontId.Title, 
+								color = COLOR_LIGHT 
+							});
+						});
+					});
+				});
+			});
+#pragma format restore
+		}
+
+		static void HandleRendererButtonInteraction(ElementId elementId, PointerData pointerInfo, void* userData)
+		{
+			int index = (int)userData;
+#pragma format disable
+			if (pointerInfo.state == .ClayPointerDataPressedThisFrame) {
+				sActiveRendererIndex = (uint32)index;
+				//Clay_SetCullingEnabled(sActiveRendererIndex == 1);
+				//Clay_SetExternalScrollHandlingEnabled(sActiveRendererIndex == 0);
+			}
+#pragma format restore
+		}
+
+		/*public static bool Clay_Hovered()
+		{
+			return false;
+		}*/
+
+		static void RendererButtonActive(String text)
+		{
+#pragma format disable
+			Elem.UI(.() {
+				layout = .(){
+					sizing = Sizing { width = Fixed(300) },
+					padding = Padding(16)
+				},
+				backgroundColor = Clay_Hovered() ? COLOR_RED_HOVER : COLOR_RED,
+				cornerRadius = CornerRadius(10)
+			}, scope () => {
+				Text(text, .() {
+					disablePointerEvents = true,
+					size = 28,
+					font = FontId.Body,
+					color = COLOR_LIGHT
+				});
+			});
+#pragma format restore
+		}
+
+		static void RenderButtonInactive_OnHover(ElementId id, PointerData pointerData, void* userData)
+		{
+		}
+
+		static void RendererButtonInactive(String text, int64 rendererIndex)
+		{
+
+
+			// var bgColor = Clay_PointerOver(ID("CanvasRenderer")) ? COLOR_LIGHT_HOVER : COLOR_LIGHT;
+#pragma format disable
+			Elem.UI(.() {
+	            // id=ID("CanvasRenderer"),
+				layout = .() { 
+					sizing = Sizing {
+						width = Fixed(300)
+					}, 
+					padding = Padding(16) 
+				},
+	            backgroundColor = Clay_Hovered() ? COLOR_LIGHT_HOVER : COLOR_LIGHT,
+				// backgroundColor = bgColor,
+				cornerRadius = CornerRadius(10),
+				border = .(2, COLOR_RED)
+				//Clay_OnHover(HandleRendererButtonInteraction, rendererIndex)
+			}, scope () => {
+	            // uint64 rIndex = (.)rendererIndex;
+	            Clay_OnHover(=> HandleRendererButtonInteraction, (void*)(int)rendererIndex);
+				Text(text, .() {
+					disablePointerEvents = true, 
+					size = 28, 
+					font = FontId.Body, 
+					color = COLOR_RED 
+				});
+			});
+#pragma format restore
+		}
+
+		static void RendererPageDesktop()
+		{
+#pragma format disable
+			UI(.() {
+				id = ID("RendererPageDesktop"), 
+				layout = .() { 
+					sizing = .(GrowMin(0), FitMin(GetScreenHeight() - 50)), 
+					alignment = .(0, .Center),  
+					padding = .(50, 0)
+				}
+			}, scope () => {
+				UI(.() {
+					id = ID("RendererPage"), 
 					layout = .() { 
-						sizing = .(Percent(0.5f), GrowMin(0)), 
+						sizing = .(GrowMin(0), GrowMin(0)),  
 						alignment = .(.Center, .Center), 
-						direction = .TopToBottom, 
-						gap = 16 
+						padding = Padding(32),
+						gap = 32 
+					}, 
+					border = .() {
+						width = .(2, 2, 0, 0, 0),
+						color = COLOR_RED
 					}
 				}, scope () => {
-					Text("Try changing renderer!", .() { 
-						size = 36, 
-						font = FontId.Body36, 
-						color = COLOR_ORANGE 
+					UI(.() {
+						id = ID("RendererLeftText"), 
+						layout = .() { 
+							sizing = Sizing { width = Percent(0.5f) },
+							direction = .TopToBottom, 
+							gap = 8
+						}
+					}, scope () => {
+						Text("Renderer & Platform Agnostic", .() { 
+							size = 52, 
+							font = FontId.Title, 
+							color = COLOR_RED 
+						});
+
+						UI(.() {
+							id = ID("RendererSpacerLeft"), 
+							layout = .() { 
+								sizing = Sizing { height = Fixed(16) }
+							}
+						});
+
+						Text("Clay outputs a sorted array of primitive render commands, such as RECTANGLE, TEXT or IMAGE.", .() { 
+							size = 28, 
+							font = FontId.Body, 
+							color = COLOR_RED 
+						});
+
+						Text("Write your own renderer in a few hundred lines of code, or use the provided examples for Raylib, WebGL canvas and more.", .() { 
+							size = 28, 
+							font = FontId.Body, 
+							color = COLOR_RED 
+						});
+
+						Text("There's even an HTML renderer - you're looking at it right now!", .() { 
+							size = 28, 
+							font = FontId.Body, 
+							color = COLOR_RED 
+						});
 					});
 
 					UI(.() {
-						id = ID("RendererSpacerRight"), 
+						id = ID("RendererRightText"), 
 						layout = .() { 
-							//sizing = { Sizing(.max = 32) } 
+							sizing = .(Percent(0.5f), GrowMin(0)), 
+							alignment = .(.Center, .Center), 
+							direction = .TopToBottom, 
+							gap = 16 
+						}
+					}, scope () => {
+						Text("Try changing renderer!", .() { 
+							size = 36, 
+							font = FontId.Body, 
+							color = COLOR_ORANGE 
+						});
+
+						UI(.() {
+							id = ID("RendererSpacerRight"), 
+							layout = .() { 
+								//sizing = { Sizing(.max = 32) } 
+							}
+						});
+
+						if (sActiveRendererIndex == 0) {
+							RendererButtonActive("HTML Renderer");
+							RendererButtonInactive("Canvas Renderer", 1);
+						} else {
+							RendererButtonInactive("HTML Renderer", 0);
+							RendererButtonActive("Canvas Renderer");
 						}
 					});
+				});
+			});
+#pragma format restore
+		}
 
-					if (sActiveRendererIndex == 0) {
+		static void RendererPageMobile()
+		{
+#pragma format disable
+			/*UI(.() {
+				id = ID("RendererMobile"), 
+				layout = .() { direction = .TopToBottom, 
+			sizing = { Sizing(0), Fit(min = windowHeight - 50) }, 
+			alignment = {.x = .Center, y = .AlignYCenter}, 
+			padding = { 16, 16, 32, 32}, 
+			gap = 32 
+			}, Rectangle({ color = COLOR_LIGHT 
+			})) {
+				UI(.() {
+					id = ID("RendererLeftText"), 
+					layout = .() { 
+					sizing = { Sizing(0) }, 
+				direction = .TopToBottom, 
+				gap = 8 
+				})) {
+					Text("Renderer & Platform Agnostic", .() { 
+						size = 48, 
+						font = Font.Title56, 
+						color = COLOR_RED 
+					}));
+					UI(.() {
+						id = ID("RendererSpacerLeft"), 
+						layout = .() { 
+						sizing = { Sizing(.max = 16) }})) {}
+					Text("Clay outputs a sorted array of primitive render commands, such as RECTANGLE, TEXT or IMAGE.", .() { 
+						size = 28, 
+						font = Font.Body36, 
+						color = COLOR_RED 
+					}));
+					Text("Write your own renderer in a few hundred lines of code, or use the provided examples for Raylib, WebGL canvas and more.", .() { 
+						size = 28, 
+						font = Font.Body36, 
+						color = COLOR_RED 
+					}));
+					Text("There's even an HTML renderer - you're looking at it right now!", .() { 
+						size = 28, 
+						font = Font.Body36, 
+						color = COLOR_RED 
+					}));
+				}
+				UI(.() {
+					id = ID("RendererRightText"), 
+					layout = .() { 
+					sizing = { Sizing(0) }, 
+				direction = .TopToBottom, 
+				gap = 16 
+				})) {
+					Text("Try changing renderer!", .() { 
+						size = 36, 
+						font = Font.Body36, 
+						color = COLOR_ORANGE 
+					}));
+					UI(.() {
+						id = ID("RendererSpacerRight"), 
+						layout = .() { 
+						sizing = { Sizing(.max = 32) }})) {}
+					if (ACTIVE_RENDERER_INDEX == 0) {
 						RendererButtonActive("HTML Renderer");
 						RendererButtonInactive("Canvas Renderer", 1);
 					} else {
 						RendererButtonInactive("HTML Renderer", 0);
 						RendererButtonActive("Canvas Renderer");
 					}
-				});
-			});
-		});
+				}
+			}*/
 #pragma format restore
-	}
+		}
 
-	static void RendererPageMobile()
-	{
+		static void DebuggerPageDesktop()
+		{
 #pragma format disable
-		/*UI(.() {
-			id = ID("RendererMobile"), 
-			layout = .() { direction = .TopToBottom, 
-		sizing = { Sizing(0), Fit(min = windowHeight - 50) }, 
-		alignment = {.x = .Center, y = .AlignYCenter}, 
-		padding = { 16, 16, 32, 32}, 
-		gap = 32 
-		}, Rectangle({ color = COLOR_LIGHT 
-		})) {
 			UI(.() {
-				id = ID("RendererLeftText"), 
+				id = ID("DebuggerDesktop"), 
 				layout = .() { 
-				sizing = { Sizing(0) }, 
-			direction = .TopToBottom, 
-			gap = 8 
-			})) {
-				Text("Renderer & Platform Agnostic", .() { 
-					size = 48, 
-					font = Font.Title56, 
-					color = COLOR_RED 
-				}));
-				UI(.() {
-					id = ID("RendererSpacerLeft"), 
-					layout = .() { 
-					sizing = { Sizing(.max = 16) }})) {}
-				Text("Clay outputs a sorted array of primitive render commands, such as RECTANGLE, TEXT or IMAGE.", .() { 
-					size = 28, 
-					font = Font.Body36, 
-					color = COLOR_RED 
-				}));
-				Text("Write your own renderer in a few hundred lines of code, or use the provided examples for Raylib, WebGL canvas and more.", .() { 
-					size = 28, 
-					font = Font.Body36, 
-					color = COLOR_RED 
-				}));
-				Text("There's even an HTML renderer - you're looking at it right now!", .() { 
-					size = 28, 
-					font = Font.Body36, 
-					color = COLOR_RED 
-				}));
-			}
-			UI(.() {
-				id = ID("RendererRightText"), 
-				layout = .() { 
-				sizing = { Sizing(0) }, 
-			direction = .TopToBottom, 
-			gap = 16 
-			})) {
-				Text("Try changing renderer!", .() { 
-					size = 36, 
-					font = Font.Body36, 
-					color = COLOR_ORANGE 
-				}));
-				UI(.() {
-					id = ID("RendererSpacerRight"), 
-					layout = .() { 
-					sizing = { Sizing(.max = 32) }})) {}
-				if (ACTIVE_RENDERER_INDEX == 0) {
-					RendererButtonActive("HTML Renderer");
-					RendererButtonInactive("Canvas Renderer", 1);
-				} else {
-					RendererButtonInactive("HTML Renderer", 0);
-					RendererButtonActive("Canvas Renderer");
-				}
-			}
-		}*/
-#pragma format restore
-	}
-
-	static void DebuggerPageDesktop()
-	{
-#pragma format disable
-		UI(.() {
-			id = ID("DebuggerDesktop"), 
-			layout = .() { 
-				sizing = .(GrowMin(0), FitMin(GetScreenHeight() - 50)), 
-				alignment = .(0, .Center),
-				padding = .(82, 82, 32, 32),
-				gap = 64 
-			},
-			backgroundColor = COLOR_RED
-		}, scope () => {
-			UI(.() {
-				id = ID("DebuggerLeftText"), 
-				layout = .() { 
-					sizing = Sizing { width = Percent(0.5f) }, 
-					direction = .TopToBottom, 
-					gap = 8 
-				}
-			}, scope () => {
-				Text("Integrated Debug Tools", .() { 
-					size = 52, 
-					font = FontId.Title56, 
-					color = COLOR_LIGHT 
-				});
-	
-				UI(.() {
-					id = ID("DebuggerSpacer"), 
-					layout = .() { 
-						//sizing = { Sizing(.max = 16) }
-					}
-				});
-	
-				Text("Clay includes built in \"Chrome Inspector\"-style debug tooling.", .() { 
-					size = 28, 
-					font = FontId.Body36, 
-					color = COLOR_LIGHT 
-				});
-	
-				Text("View your layout hierarchy and config in real time.", .() { 
-					size = 28, 
-					font = FontId.Body36, 
-					color = COLOR_LIGHT 
-				});
-	
-				UI(.() {
-					id = ID("DebuggerPageSpacer"), 
-					layout = .() { 
-						sizing = Sizing { width = Percent(100), height = Fixed(32) }
-					}
-				});
-	
-				Text("Press the \"d\" key to try it out now!", .() { 
-					size = 32, 
-					font = FontId.Title36, 
-					color = COLOR_ORANGE 
-				});
-			});
-
-			UI(.() {
-				id = ID("DebuggerRightImageOuter"), 
-				layout = .() { 
-					sizing = Sizing {
-						width = Percent(0.50f)
-					},
-					alignment = .(.Center, .Center)
-				}
+					sizing = .(GrowMin(0), FitMin(GetScreenHeight() - 50)), 
+					alignment = .(0, .Center),
+					padding = .(82, 82, 32, 32),
+					gap = 64 
+				},
+				backgroundColor = COLOR_RED
 			}, scope () => {
 				UI(.() {
-					id = ID("DebuggerPageRightImageInner"), 
-					layout = .() {
-						sizing = Sizing {
-							width = GrowMax(558)
-						} 
-					},
-					image = .() {
-						dimensions = .(1620, 1474),
-						data = &Debugger
+					id = ID("DebuggerLeftText"), 
+					layout = .() { 
+						sizing = Sizing { width = Percent(0.5f) }, 
+						direction = .TopToBottom, 
+						gap = 8 
 					}
-				});
-			});
-		});
-#pragma format restore
-	}
-
-	struct ScrollbarData
-	{
-		public Vector2 clickOrigin;
-		public Vector2 positionOrigin;
-		public bool mouseDown;
-	};
-
-	static ScrollbarData scrollbarData = .();
-	static float animationLerpValue = -1.0f;
-
-	static void TopBorder(String id, Color color)
-	{
-		UI(.()
-			{
-				id = ID(id),
-				layout = .() { sizing = .(Percent(1), Fixed(4)) },
-				backgroundColor = color
-			});
-	};
-
-	static Array<RenderCommand> CreateLayout(bool mobileScreen, float lerpValue)
-	{
-		Clay_BeginLayout();
-
-#pragma format disable
-		UI(.() {
-			id = ID("OuterContainer"),
-			layout = .() {
-				direction = .TopToBottom,
-				sizing = Sizing { width = Percent(1), height = Percent(1) }
-			},
-			//backgroundColor = COLOR_LIGHT
-			backgroundColor = Clay_Hovered() ? COLOR_LIGHT_HOVER : COLOR_LIGHT
-		}, scope () => {
-			
-			UI(.() {
-				id = ID("Header"),
-				layout = .() {
-					sizing = .(Percent(1), Fixed(50)),
-					alignment = .( .Left, .Center),
-					direction = .LeftToRight,
-					gap = 16,
-					padding = .(32, 32, 0, 0)
-				}
-			}, scope () => {
-				Text("Clay", headerTextConfig);
-
-				UI(.() {
-					id = ID("Spacer"),
-					layout = .() {
-						sizing = Sizing {
-							width = GrowMin(1)
+				}, scope () => {
+					Text("Integrated Debug Tools", .() { 
+						size = 52, 
+						font = FontId.Title, 
+						color = COLOR_LIGHT 
+					});
+		
+					UI(.() {
+						id = ID("DebuggerSpacer"), 
+						layout = .() { 
+							//sizing = { Sizing(.max = 16) }
 						}
-					}
+					});
+		
+					Text("Clay includes built in \"Chrome Inspector\"-style debug tooling.", .() { 
+						size = 28, 
+						font = FontId.Body, 
+						color = COLOR_LIGHT 
+					});
+		
+					Text("View your layout hierarchy and config in real time.", .() { 
+						size = 28, 
+						font = FontId.Body, 
+						color = COLOR_LIGHT 
+					});
+		
+					UI(.() {
+						id = ID("DebuggerPageSpacer"), 
+						layout = .() { 
+							sizing = Sizing { width = Percent(100), height = Fixed(32) }
+						}
+					});
+		
+					Text("Press the \"d\" key to try it out now!", .() { 
+						size = 32, 
+						font = FontId.Title, 
+						color = COLOR_ORANGE 
+					});
 				});
 
-				if (!mobileScreen) {
-					UI(.() {
-						id = ID("LinkExamplesOuter"),
-						layout = .() {
-							direction = .LeftToRight,
-							padding = .(8, 8, 0, 0)
+				UI(.() {
+					id = ID("DebuggerRightImageOuter"), 
+					layout = .() { 
+						sizing = Sizing {
+							width = Percent(0.50f)
 						},
-						backgroundColor = .(0, 0, 0, 0)
-					}, scope () => {
-						Text("Examples", .() {
-							disablePointerEvents = true, 
-							font = FontId.Body24, 
-							size = 24, 
-							color = .(61, 26, 5, 255)
-						});
-					});
-
+						alignment = .(.Center, .Center)
+					}
+				}, scope () => {
 					UI(.() {
-						id = ID("LinkDocsOuter"),
+						id = ID("DebuggerPageRightImageInner"), 
 						layout = .() {
-							padding = .(8, 8, 0, 0)
+							sizing = Sizing {
+								width = GrowMax(558)
+							} 
 						},
-						backgroundColor = .(0, 0, 0, 0)
-					}, scope () => {
-						Text("Docs", .() {
-							disablePointerEvents = true, 
-							font = FontId.Body24, 
-							size = 24, 
-							color = .(61, 26, 5, 255)
-						});
+						image = .() {
+							dimensions = .(1620, 1474),
+							data = &Debugger
+						}
 					});
-
-					UI(.() {
-						id = ID("DiscordLink"),
-						layout = .() {
-							padding = .(16, 16, 6, 6)
-						},
-						cornerRadius = CornerRadius(10),
-						backgroundColor = Clay_Hovered() ? COLOR_LIGHT_HOVER : COLOR_LIGHT,
-						border = .(2, COLOR_RED)
-					}, scope () => {
-						Text("Discord", .() {
-							disablePointerEvents = true, 
-							font = FontId.Body24, 
-							size = 24, 
-							color = .(61, 26, 5, 255)
-						});
-					});
-
-					UI(.() {
-						id = ID("GithubLink"),
-						layout = .() {
-							padding = .(16, 16, 6, 6)
-						},
-						cornerRadius = CornerRadius(10),
-						backgroundColor = Clay_Hovered() ? COLOR_LIGHT_HOVER : COLOR_LIGHT,
-						border = .(2, COLOR_RED)
-					}, scope () => {
-						Text("Github", .() {
-							disablePointerEvents = true, 
-							font = FontId.Body28, 
-							size = 24, 
-							color = .(61, 26, 5, 255)
-						});
-					});
-				}
+				});
 			});
-
-			TopBorder("TopBorder1", COLOR_TOP_BORDER_5);
-			TopBorder("TopBorder2", COLOR_TOP_BORDER_4);
-			TopBorder("TopBorder3", COLOR_TOP_BORDER_3);
-			TopBorder("TopBorder4", COLOR_TOP_BORDER_2);
-			TopBorder("TopBorder5", COLOR_TOP_BORDER_1);
-
-			UI(.() {
-				id = ID("OuterScrollContainer"),
-				scroll = .(false, true),
-				layout = .() { 
-					sizing = .(Percent(1), Percent(1)), 
-					direction = .TopToBottom 
-				},
-				border = .() {
-					width = BorderWidth { betweenChildren = 2 },
-					color = COLOR_RED
-				}
-			}, scope () => {
-				if (mobileScreen) {
-					LandingPageMobile();
-					FeatureBlocksMobile();
-					DeclarativeSyntaxPageMobile();
-					HighPerformancePageMobile(lerpValue);
-					RendererPageMobile();
-				} else {
-					LandingPageDesktop();
-					FeatureBlocksDesktop();
-					DeclarativeSyntaxPageDesktop();
-					HighPerformancePageDesktop(lerpValue);
-					RendererPageDesktop();
-					DebuggerPageDesktop();
-				}
-			});
-		});
-
-		if (!mobileScreen && sActiveRendererIndex == 0)
-		{
-			ScrollContainerData scrollData = Clay_GetScrollContainerData(Clay_GetElementId("OuterScrollContainer"));
-
-			Color scrollbarColor = .(225, 138, 50, 120);
-
-			if (scrollbarData.mouseDown)
-			{
-				scrollbarColor = .( 225, 138, 50, 200 );
-			} else if (Clay_PointerOver(Clay_GetElementId("ScrollBar")))
-			{
-				scrollbarColor = .(  225, 138, 50, 160 );
-			}
-
-			float scrollHeight = scrollData.scrollContainerDimensions.height - 12;
-
-			/*UI(.() {
-				id = ID("ScrollBar"),
-				floating = .()
-				{
-					offset = .(-6, -(scrollData.scrollPosition.y / scrollData.contentDimensions.height) * scrollHeight + 6),
-					zIndex = 1,
-					parentId = Clay_GetElementId("OuterScrollContainer").id,
-					attachPoints = .() {
-						element = .RightTop, parent = .RightTop }
-				},
-				layout = .(){
-					sizing = .(Fixed(10), Fixed((scrollHeight / scrollData.contentDimensions.height) * scrollHeight))
-				},
-				cornerRadius = CornerRadius(5),
-				backgroundColor = scrollbarColor
-			});*/
-		}
 #pragma format restore
+		}
 
-		return Clay_EndLayout();
-	}
-
-	public static void Update(float mouseX, float mouseY, float wheelX, float wheelY, bool mousePressed)
-	{
-		Clay_SetLayoutDimensions(.(GetScreenWidth(), GetScreenHeight()));
-		Clay_SetPointerState(.(mouseX, mouseY), mousePressed);
-		Clay_UpdateScrollContainers(true, .(wheelX * 10, wheelY * 10), GetFrameTime());
-
-		ScrollContainerData scrollContainerData = Clay_GetScrollContainerData(Clay_GetElementId("OuterScrollContainer"));
-
-		if (scrollContainerData.contentDimensions.height > 0)
+		struct ScrollbarData
 		{
-			if (IsKeyDown(.KeyDown))
+			public Vector2 clickOrigin;
+			public Vector2 positionOrigin;
+			public bool mouseDown;
+		};
+
+		static ScrollbarData scrollbarData = .();
+		static float animationLerpValue = -1.0f;
+
+		static void TopBorder(String id, Color color)
+		{
+			UI(.()
+				{
+					id = ID(id),
+					layout = .() { sizing = .(Percent(1), Fixed(4)) },
+					backgroundColor = color
+				});
+		};
+
+		static Array<RenderCommand> CreateLayout(bool mobileScreen, float lerpValue)
+		{
+			let timer = scope Stopwatch(true);
+			defer
 			{
-				scrollContainerData.scrollPosition.y = scrollContainerData.scrollPosition.y - 50;
-			} else if (IsKeyDown(.KeyUp))
-			{
-				scrollContainerData.scrollPosition.y = scrollContainerData.scrollPosition.y + 50;
+				if (mShowTimer)
+				{
+					System.Console.WriteLine($"Scope took {timer.ElapsedMicroseconds}us.");
+					mShowTimer = false;
+				}
 			}
+			Clay_BeginLayout();
+
+#pragma format disable
+			Elem.UI(.(){
+			    layout = .() {
+			        direction = .TopToBottom,
+			        //padding = .(default, default, 50, default),
+			        sizing = .(.Percent(1), .Percent(1))
+			    }
+			}, scope () => {
+			    Elem.UI(.() {
+			    	id = ID("OuterContainer"),
+			    	layout = .() {
+			    		direction = .TopToBottom,
+			    		sizing = Sizing { width = Percent(1), height = Percent(1) }
+			    	},
+			    	backgroundColor = COLOR_LIGHT
+			    }, scope () => {
+			    	
+			    	UI(.() {
+			    		id = ID("Header"),
+			    		layout = .() {
+			    			sizing = .(Percent(1), Fixed(50)),
+			    			alignment = .( .Left, .Center),
+			    			direction = .LeftToRight,
+			    			gap = 16,
+			    			padding = .(32, 32, 0, 0)
+			    		}
+			    	}, scope () => {
+			    		Text("Clay", headerTextConfig);
+
+			    		UI(.() {
+			    			id = ID("Spacer"),
+			    			layout = .() {
+			    				sizing = Sizing {
+			    					width = GrowMin(1)
+			    				}
+			    			}
+			    		});
+
+			    		if (!mobileScreen) {
+			    			UI(.() {
+			    				id = ID("LinkExamplesOuter"),
+			    				layout = .() {
+			    					direction = .LeftToRight,
+			    					padding = .(8, 8, 0, 0)
+			    				},
+			    				backgroundColor = .(0, 0, 0, 0)
+			    			}, scope () => {
+			    				Text("Examples", .() {
+			    					disablePointerEvents = true, 
+			    					font = FontId.Body, 
+			    					size = 24, 
+			    					color = .(61, 26, 5, 255)
+			    				});
+			    			});
+
+			    			UI(.() {
+			    				id = ID("LinkDocsOuter"),
+			    				layout = .() {
+			    					padding = .(8, 8, 0, 0)
+			    				},
+			    				backgroundColor = .(0, 0, 0, 0)
+			    			}, scope () => {
+			    				Text("Docs", .() {
+			    					disablePointerEvents = true, 
+			    					font = FontId.Body, 
+			    					size = 24, 
+			    					color = .(61, 26, 5, 255)
+			    				});
+			    			});
+
+			    			Elem.UI(.() {
+			    				// id = ID("DiscordLink"),	// Clay_Hovered does not work with an id.
+			    				layout = .() {
+			    					padding = .(16, 16, 6, 6)
+			    				},
+			    				cornerRadius = CornerRadius(10),
+			    				backgroundColor = Clay_Hovered() ? COLOR_LIGHT_HOVER : COLOR_LIGHT,
+			    				border = .(2, COLOR_RED)
+			    			}, scope () => {
+			    				Text("Discord", .() {
+			    					disablePointerEvents = true, 
+			    					font = FontId.Body, 
+			    					size = 24, 
+			    					color = .(61, 26, 5, 255)
+			    				});
+			    			});
+
+			    			Elem.UI(.() {
+			    				// id = ID("GithubLink"),  // Clay_Hovered does not work with an id.
+			    				layout = .() {
+			    					padding = .(16, 16, 6, 6)
+			    				},
+			    				cornerRadius = CornerRadius(10),
+			    				backgroundColor = Clay_Hovered() ? COLOR_LIGHT_HOVER : COLOR_LIGHT,
+			    				border = .(2, COLOR_RED)
+			    			}, scope () => {
+			    				Text("Github", .() {
+			    					disablePointerEvents = true, 
+			    					font = FontId.Body, 
+			    					size = 24, 
+			    					color = .(61, 26, 5, 255)
+			    				});
+			    			});
+			    		}
+			    	});
+
+			    	TopBorder("TopBorder1", COLOR_TOP_BORDER_5);
+			    	TopBorder("TopBorder2", COLOR_TOP_BORDER_4);
+			    	TopBorder("TopBorder3", COLOR_TOP_BORDER_3);
+			    	TopBorder("TopBorder4", COLOR_TOP_BORDER_2);
+			    	TopBorder("TopBorder5", COLOR_TOP_BORDER_1);
+
+			    	UI(.() {
+			    		id = ID("OuterScrollContainer"),
+			    		scroll = .(false, true),
+			    		layout = .() { 
+			    			sizing = .(Percent(1), Percent(1)), 
+			    			direction = .TopToBottom 
+			    		},
+			    		border = .() {
+			    			width = BorderWidth { betweenChildren = 2 },
+			    			color = COLOR_RED
+			    		}
+			    	}, scope () => {
+			    		if (mobileScreen) {
+			    			LandingPageMobile();
+			    			FeatureBlocksMobile();
+			    			DeclarativeSyntaxPageMobile();
+			    			HighPerformancePageMobile(lerpValue);
+			    			RendererPageMobile();
+			    		} else {
+			    			LandingPageDesktop();
+			    			FeatureBlocksDesktop();
+			    			DeclarativeSyntaxPageDesktop();
+			    			HighPerformancePageDesktop(lerpValue);
+			    			RendererPageDesktop();
+			    			DebuggerPageDesktop();
+			    		}
+			    	});
+			    });
+
+			    
+			    if (!mobileScreen /*&& sActiveRendererIndex == 0*/)
+			    {
+			    	ScrollContainerData scrollData = Clay_GetScrollContainerData(Clay_GetElementId("OuterScrollContainer"));
+
+			    	Color scrollbarColor = .(225, 138, 50, 120);
+
+
+			    	if (scrollbarData.mouseDown)
+			    	{
+			    		scrollbarColor = .( 225, 138, 50, 200 );
+			    	} else if (Clay_PointerOver(Clay_GetElementId("ScrollBar")))
+			    	{
+			    		scrollbarColor = .(  225, 138, 50, 160 );
+			    	}
+
+			    	float scrollHeight = scrollData.scrollContainerDimensions.height - 70;
+			        
+
+			    	UI(.() {
+			    		id = ID("ScrollBar"),
+			    		floating = .()
+			    		{
+			    			offset = .(-6, -(scrollData.scrollPosition.y / scrollData.contentDimensions.height) * scrollHeight + 6),
+			    			parentId = Clay_GetElementId("OuterScrollContainer").id,
+			          	attachTo = .ElementWithId,
+			    			attachPoints = .() {
+			    				element = .RightTop, parent = .RightTop }
+			    		},
+			    		layout = .(){
+			                sizing = .(Fixed(10), Fixed((scrollHeight / scrollData.contentDimensions.height) * scrollHeight))
+			    		},
+			    		cornerRadius = CornerRadius(5),
+			    		backgroundColor = scrollbarColor
+			    	}, scope () => {
+			            
+			            Clay_OnHover(=> ClayHomepage.OnHover, null);
+			        });
+			    }
+			});
+			return Clay_EndLayout();
 		}
 
-		animationLerpValue += GetFrameTime();
-		if (animationLerpValue > 1)
+		public static void OnHover(ElementId elementId, PointerData pointerData, void* userData)
 		{
-			animationLerpValue -= 2;
+			// (scope $"On hover: {elementId.id}");
 		}
 
-		var renderCommands = CreateLayout(false, animationLerpValue < 0 ? (animationLerpValue + 1) : (1 - animationLerpValue));
+		public static void Update(float mouseX, float mouseY, float wheelX, float wheelY, bool mousePressed)
+		{
+			Clay_SetLayoutDimensions(.(GetScreenWidth(), GetScreenHeight()));
+			Clay_SetPointerState(.(mouseX, mouseY), mousePressed);
+			Clay_UpdateScrollContainers(true, .(wheelX * 10, wheelY * 10), GetFrameTime());
 
-		RendererRaylib.Render(&renderCommands);
+			ScrollContainerData scrollContainerData = Clay_GetScrollContainerData(Clay_GetElementId("OuterScrollContainer"));
+
+			if (scrollContainerData.contentDimensions.height > 0)
+			{
+				//if (IsKeyDown(.KeyDown))
+				if (IsKeyDown(.KEY_DOWN))
+				{
+					scrollContainerData.scrollPosition.y = scrollContainerData.scrollPosition.y - 50;
+				} else if (IsKeyDown(.KEY_UP))
+				{
+					scrollContainerData.scrollPosition.y = scrollContainerData.scrollPosition.y + 50;
+				} else if (IsKeyDown(.KEY_SPACE))
+				{
+					mShowTimer = true;
+				} else if (IsKeyPressed(.KEY_D))
+				{
+					Clay_SetDebugModeEnabled(true);
+				} else if (IsKeyPressed(.KEY_E))
+				{
+					Clay_SetDebugModeEnabled(false);
+				}
+			}
+
+			var frameTime = GetFrameTime();
+			animationLerpValue += frameTime;
+			if (animationLerpValue > 1)
+			{
+				animationLerpValue -= 2;
+			}
+
+			renderCommands = CreateLayout(false,animationLerpValue< 0 ? (animationLerpValue + 1) : (1 - animationLerpValue));
+		}
+
+
+		public static void Draw()
+		{
+			RendererRaylib.Render(&renderCommands);
+		}
 	}
-}

--- a/src/Clay.bf
+++ b/src/Clay.bf
@@ -6,6 +6,33 @@ namespace Clay;
 
 public static class Clay
 {
+	public const Color LIGHTGRAY = Color(200, 200, 200, 255);
+	public const Color GRAY = Color(130, 130, 130, 255);
+	public const Color DARKGRAY = Color(80, 80, 80, 255);
+	public const Color YELLOW = Color(253, 249, 0, 255);
+	public const Color GOLD = Color(255, 203, 0, 255);
+	public const Color ORANGE = Color(255, 161, 0, 255);
+	public const Color PINK = Color(255, 109, 194, 255);
+	public const Color RED = Color(230, 41, 55, 255);
+	public const Color MAROON = Color(190, 33, 55, 255);
+	public const Color GREEN = Color(0, 228, 48, 255);
+	public const Color LIME = Color(0, 158, 47, 255);
+	public const Color DARKGREEN = Color(0, 117, 44, 255);
+	public const Color SKYBLUE = Color(102, 191, 255, 255);
+	public const Color BLUE = Color(0, 121, 241, 255);
+	public const Color DARKBLUE = Color(0, 82, 172, 255);
+	public const Color PURPLE = Color(200, 122, 255, 255);
+	public const Color VIOLET = Color(135, 60, 190, 255);
+	public const Color DARKPURPLE = Color(112, 31, 126, 255);
+	public const Color BEIGE = Color(211, 176, 131, 255);
+	public const Color BROWN = Color(127, 106, 79, 255);
+	public const Color DARKBROWN = Color(76, 63, 47, 255);
+	public const Color WHITE = Color(255, 255, 255, 255);
+	public const Color BLACK = Color(0, 0, 0, 255);
+	public const Color BLANK = Color(0, 0, 0, 0);
+	public const Color MAGENTA = Color(255, 0, 255, 255);
+	public const Color RAYWHITE = Color(245, 245, 245, 255);
+
 	public typealias OnHoverFunction = function void(ElementId elementId, PointerData pointerData, void* userData);
 
 	[Comptime] public static bool Clay_PointerOver(System.String id)
@@ -84,6 +111,8 @@ public static class Clay
 	{
 		public float r = 0, g = 0, b = 0, a = 0;
 
+		private const float BrightnessChangeAmount = 32;
+
 		public this(float r = 0, float g = 0, float b = 0, float a = 0)
 		{
 			this.r = r;
@@ -92,7 +121,18 @@ public static class Clay
 			this.a = a;
 		}
 
-		public implicit static operator Color(RaylibBeef.Color c) => .(c.r, c.g, c.b, c.a);
+		private static float Darker(float value)
+		{
+			return Math.Max(0, value - BrightnessChangeAmount);
+		}
+
+		private static float Lighter(float value)
+		{
+			return Math.Min(255, value + BrightnessChangeAmount);
+		}
+
+		public Color Lighter => .(Lighter(r), Lighter(g), Lighter(b), a);
+		public Color Darker => .(Darker(r), Darker(g), Darker(b), a);
 	}
 
 	[CRepr]

--- a/src/FontManager.bf
+++ b/src/FontManager.bf
@@ -1,0 +1,69 @@
+namespace Clay;
+
+using System;
+using System.Collections;
+
+using RaylibBeef;
+
+
+public struct FontSpec : IHashable
+{
+	public uint FontId;
+	public uint FontSize;
+	public this(uint fontId, uint fontSize)
+	{
+		FontId = fontId;
+		FontSize = fontSize;
+	}
+	public int GetHashCode()
+	{
+		return HashCode.Generate((FontId, FontSize));
+	}
+}
+
+public class FontManager
+{
+    private static Dictionary<uint, StringView> mFontPaths = new .(1024) ~ delete _;
+    private static String mPathBuffer = new .(1024 * 1024) ~ delete _;
+    private static Dictionary<FontSpec, RaylibBeef.Font> mFonts = new .(1024) ~ delete _;
+
+    public static void RegisterFont(uint fontId, StringView path, params uint[] preloadSizes)
+    {
+        Runtime.Assert(!mFontPaths.ContainsKey(fontId), "Register the font only once.");
+        int startIndex = mPathBuffer.Length;
+        String nullTerminatedPath = scope $"{path}\0";
+        mPathBuffer.Append(nullTerminatedPath);
+        mFontPaths[fontId] = mPathBuffer.Substring(startIndex);
+
+		for(var eachSize in preloadSizes)
+		{
+			LoadFont(fontId, eachSize);
+		}
+    }
+
+    public static RaylibBeef.Font LoadFont(uint fontId, uint fontSize)
+    {
+        Runtime.Assert(mFontPaths.ContainsKey(fontId));
+        var spec = FontSpec(fontId, fontSize);
+        if(!mFonts.ContainsKey(spec))
+        {
+            var path = mFontPaths[fontId];
+            let font = Raylib.LoadFontEx(path.Ptr, (.)fontSize, null, 0);
+            Raylib.SetTextureFilter(font.texture, RaylibBeef.TextureFilter.TEXTURE_FILTER_TRILINEAR);
+            mFonts.Add(spec, font);
+        }
+
+        return mFonts[spec];
+    }
+
+    public static RaylibBeef.Font GetFont(uint fontId, uint fontSize)
+    {
+        FontSpec spec = .(fontId, fontSize);
+        if(!mFonts.ContainsKey(spec))
+        {
+            LoadFont(fontId, fontSize);
+        }
+
+        return mFonts[spec];
+    }
+}


### PR DESCRIPTION
## 1: Fixed example to match Raylib API

1. `RaylibBeef.ConfigFlags.FlagMsaa4XHint` becomes `RaylibBeef.ConfigFlags.FLAG_MSAA_4X_HINT`
2. `SetWindowState(.FlagWindowResizable);` becomes `SetWindowState(.FLAG_WINDOW_RESIZABLE);`

## 2: Added Update/Render cycle.
1. Takes Clay declarations outside of Raylib's `[Begin/End]Drawing`
2. This makes it easier to use with other rendering code (e.g. rendering textures while updating the layout).

## 3: Added support for `Clay_OnHover` and `Clay_Hovered`
1. `Clay_OnHover` import was added.
2. `Clay_Hovered` needed `Clay__OpenElement()` to be called before the declaration. This has been fixed with the `Elem.UI` function.

## 4: Added `[Comptime]` for `ID()` Generation
1. This makes the feature 0-cost in runtime.
2. Also added a corresponding `Clay_Hovered(id)` function.

## 5: Added a `FontManager` class

1. This handles font loading and sizes better.
2. Font files only need to be referenced once.
3. When font size is changed at runtime, the new font size is loaded (once). Font sizes can be preloaded (shown in the example).
4. This also reduces the complexity of selecting font sizes in your layout, as you no longer need to add an enum and load that specific font.

## 6: Added Color constants (replicating Raylib) and Lighter/Darker properties to Color

1. This makes it easier to create quick color variations.